### PR TITLE
Renames package imports to github.com/RTradeLtd/libanonvpn

### DIFF
--- a/client.Dockerfile
+++ b/client.Dockerfile
@@ -1,19 +1,19 @@
 FROM alpine:3.10
-ENV I2CP_HOME=/opt/go/src/github.com/RTradeLtd/go-anonvpn/cmd/anonvpn
+ENV I2CP_HOME=/opt/go/src/github.com/RTradeLtd/libanonvpn/cmd/anonvpn
 ENV GO_I2CP_CONF=/i2cp.docker.conf
 ENV GOPATH=/opt/go/
 RUN apk update
 RUN apk add go git make musl-dev
 RUN adduser -h /home/anonvpn -g 'anonvpn,,,,' -S -D anonvpn
-COPY . /opt/go/src/github.com/RTradeLtd/go-anonvpn
+COPY . /opt/go/src/github.com/RTradeLtd/libanonvpn
 COPY etc/anonvpn/.i2cp.docker.conf \
-    /opt/go/src/github.com/RTradeLtd/go-anonvpn/etc/anonvpn/i2cp.docker.conf
-WORKDIR /opt/go/src/github.com/RTradeLtd/go-anonvpn
+    /opt/go/src/github.com/RTradeLtd/libanonvpn/etc/anonvpn/i2cp.docker.conf
+WORKDIR /opt/go/src/github.com/RTradeLtd/libanonvpn
 RUN GO111MODULE=on go mod vendor
 RUN go version
 RUN make build
 RUN apk del git make
-COPY cvpnserver.ini /opt/go/src/github.com/RTradeLtd/go-anonvpn/etc/anonvpn/anonvpn-client.ini
-CMD /opt/go/src/github.com/RTradeLtd/go-anonvpn/cmd/anonvpn/anonvpn-webview \
+COPY cvpnserver.ini /opt/go/src/github.com/RTradeLtd/libanonvpn/etc/anonvpn/anonvpn-client.ini
+CMD /opt/go/src/github.com/RTradeLtd/libanonvpn/cmd/anonvpn/anonvpn-webview \
     -littleboss=start \
-    -file /opt/go/src/github.com/RTradeLtd/go-anonvpn/etc/anonvpn/anonvpn-client.ini
+    -file /opt/go/src/github.com/RTradeLtd/libanonvpn/etc/anonvpn/anonvpn-client.ini

--- a/cmd/anonvpn/common.go
+++ b/cmd/anonvpn/common.go
@@ -9,9 +9,9 @@ import (
 )
 
 import (
-	samforwardervpn "github.com/RTradeLtd/go-anonvpn/client"
-	samtunnelhandler "github.com/RTradeLtd/go-anonvpn/ctrl"
-	samforwardervpnserver "github.com/RTradeLtd/go-anonvpn/server"
+	samforwardervpn "github.com/RTradeLtd/libanonvpn/client"
+	samtunnelhandler "github.com/RTradeLtd/libanonvpn/ctrl"
+	samforwardervpnserver "github.com/RTradeLtd/libanonvpn/server"
 	checki2p "github.com/eyedeekay/checki2cp"
 	i2pbrowserproxy "github.com/eyedeekay/httptunnel/multiproxy"
 	"github.com/eyedeekay/outproxy"

--- a/cmd/anonvpn/main.go
+++ b/cmd/anonvpn/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 import (
-	samtunnelhandler "github.com/RTradeLtd/go-anonvpn/ctrl"
+	samtunnelhandler "github.com/RTradeLtd/libanonvpn/ctrl"
 	i2pbrowserproxy "github.com/eyedeekay/httptunnel/multiproxy"
 )
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,7 +26,7 @@
     <div class="content downloads">
       <h2 id="downloads">Downloads</h2>
       <p>The software is available from our <a href=
-      "https://github.com/RTradeLtd/go-anonvpn/releases">Github Releases</a>
+      "https://github.com/RTradeLtd/libanonvpn/releases">Github Releases</a>
       page.</p>
     </div>
     <div class="content latest">
@@ -36,22 +36,22 @@
       <ul>
         <li>
           <a href=
-          "https://github.com/RTradeLtd/go-anonvpn/releases/tag/latest">Release
+          "https://github.com/RTradeLtd/libanonvpn/releases/tag/latest">Release
           Page</a>
         </li>
         <li>
           <a href=
-          "https://github.com/RTradeLtd/go-anonvpn/releases/download/latest/go-anonvpn-installer.exe">
+          "https://github.com/RTradeLtd/libanonvpn/releases/download/latest/go-anonvpn-installer.exe">
           Windows</a>
         </li>
         <li>
           <a href=
-          "https://github.com/RTradeLtd/go-anonvpn/releases/download/latest/go-anonvpn-testing_.html64.deb">
+          "https://github.com/RTradeLtd/libanonvpn/releases/download/latest/go-anonvpn-testing_.html64.deb">
           Debian</a>
         </li>
         <li>
           <a href=
-          "https://github.com/RTradeLtd/go-anonvpn/releases/download/latest/go-anonvpn.tar.gz">
+          "https://github.com/RTradeLtd/libanonvpn/releases/download/latest/go-anonvpn.tar.gz">
           Other Linux</a>
         </li>
       </ul>
@@ -64,22 +64,22 @@
       <ul>
         <li>
           <a href=
-          "https://github.com/RTradeLtd/go-anonvpn/releases/tag/stable">Release
+          "https://github.com/RTradeLtd/libanonvpn/releases/tag/stable">Release
           Page</a>
         </li>
         <li>
           <a href=
-          "https://github.com/RTradeLtd/go-anonvpn/releases/download/stable/go-anonvpn-installer.exe">
+          "https://github.com/RTradeLtd/libanonvpn/releases/download/stable/go-anonvpn-installer.exe">
           Windows</a>
         </li>
         <li>
           <a href=
-          "https://github.com/RTradeLtd/go-anonvpn/releases/download/stable/go-anonvpn-testing_.html64.deb">
+          "https://github.com/RTradeLtd/libanonvpn/releases/download/stable/go-anonvpn-testing_.html64.deb">
           Debian</a>
         </li>
         <li>
           <a href=
-          "https://github.com/RTradeLtd/go-anonvpn/releases/download/stable/go-anonvpn.tar.gz">
+          "https://github.com/RTradeLtd/libanonvpn/releases/download/stable/go-anonvpn.tar.gz">
           Other Linux</a>
         </li>
       </ul>

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/RTradeLtd/go-anonvpn
+module github.com/RTradeLtd/libanonvpn
 
 go 1.12
 

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,14 +1,14 @@
 FROM alpine:3.10
-ENV I2CP_HOME=/opt/go/src/github.com/RTradeLtd/go-anonvpn/cmd/anonvpn
+ENV I2CP_HOME=/opt/go/src/github.com/RTradeLtd/libanonvpn/cmd/anonvpn
 ENV GO_I2CP_CONF=/i2cp.docker.conf
 ENV GOPATH=/opt/go/
 RUN apk update
 RUN apk add go git make musl-dev
 RUN adduser -h /home/anonvpn -g 'anonvpn,,,,' -S -D anonvpn
-COPY . /opt/go/src/github.com/RTradeLtd/go-anonvpn
+COPY . /opt/go/src/github.com/RTradeLtd/libanonvpn
 COPY etc/anonvpn/.i2cp.docker.conf \
-    /opt/go/src/github.com/RTradeLtd/go-anonvpn/etc/anonvpn/i2cp.docker.conf
-WORKDIR /opt/go/src/github.com/RTradeLtd/go-anonvpn
+    /opt/go/src/github.com/RTradeLtd/libanonvpn/etc/anonvpn/i2cp.docker.conf
+WORKDIR /opt/go/src/github.com/RTradeLtd/libanonvpn
 #RUN GO111MODULE=on go mod vendor
 #RUN make build
 RUN make install
@@ -17,5 +17,5 @@ CMD ./cmd/bin/anonvpn \
     -samhost=i2p \
     -samport=7657 \
     -littleboss=start \
-    -file /opt/go/src/github.com/RTradeLtd/go-anonvpn/etc/anonvpn/anonvpn-server.ini
+    -file /opt/go/src/github.com/RTradeLtd/libanonvpn/etc/anonvpn/anonvpn-server.ini
 


### PR DESCRIPTION
Renames package imports from `github.com/RTradeLtd/go-anonvpn` to `github.com/RTradeLtd/libanonvpn`