### PR TITLE
disable canal for now

### DIFF
--- a/client/vpn-client.go
+++ b/client/vpn-client.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/eyedeekay/canal/simplify"
-	"github.com/eyedeekay/checki2cp"
+	//"github.com/eyedeekay/canal/simplify"
+	//"github.com/eyedeekay/checki2cp"
 	i2ptunconf "github.com/eyedeekay/sam-forwarder/config"
 	"github.com/eyedeekay/sam-forwarder/hashhash"
 	sfi2pkeys "github.com/eyedeekay/sam-forwarder/i2pkeys"
@@ -340,7 +340,7 @@ func (s *SAMClientVPN) Serve() error {
 			return err
 		}
 	}*/
-	if check, err := checki2p.CheckI2PUserName(); err == nil {
+	/*if check, err := checki2p.CheckI2PUserName(); err == nil {
 		log.Println("firewall: Tagging", check, "user firewall rules")
 		if err := firewall.Setup(localaddr.(*net.IPAddr).IP, remoteaddr.(*net.IPAddr).IP); err != nil {
 			log.Println("firewall: Error:", err.Error())
@@ -362,7 +362,7 @@ func (s *SAMClientVPN) Serve() error {
 	} else {
 		log.Println("firewall: Error: user rule, user not found.")
 		return err
-	}
+	}*/
 	s.Tunnel.Run(ctx)
 	for {
 

--- a/server/vpn-server.go
+++ b/server/vpn-server.go
@@ -16,7 +16,7 @@ import (
 	//	"time"
 
 	whitelister "github.com/eyedeekay/accessregister/auth"
-	"github.com/eyedeekay/canal"
+	//"github.com/eyedeekay/canal"
 	i2ptunconf "github.com/eyedeekay/sam-forwarder/config"
 	"github.com/eyedeekay/sam-forwarder/hashhash"
 	sfi2pkeys "github.com/eyedeekay/sam-forwarder/i2pkeys"
@@ -349,9 +349,9 @@ func (s *SAMClientServerVPN) Serve() error {
 		return err
 	}
 	go s.whiteListingTunnel.Serve()
-	if err = firewall.ServerSetup(s.Config().TunName, "eth0"); err != nil {
+	/*if err = firewall.ServerSetup(s.Config().TunName, "eth0"); err != nil {
 		return err
-	}
+	}*/
 	s.Tunnel.Run(ctx)
 
 	return nil


### PR DESCRIPTION
This disables some routing-table configuration stuff that was poorly done from the early version while the replacement is developed.