### PR TITLE
update canal to new, probably-working version

### DIFF
--- a/client/vpn-client.go
+++ b/client/vpn-client.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"syscall"
 
-	//"github.com/eyedeekay/canal/simplify"
-	//"github.com/eyedeekay/checki2cp"
 	i2ptunconf "github.com/eyedeekay/sam-forwarder/config"
 	"github.com/eyedeekay/sam-forwarder/hashhash"
 	sfi2pkeys "github.com/eyedeekay/sam-forwarder/i2pkeys"
@@ -334,35 +332,6 @@ func (s *SAMClientVPN) Serve() error {
 	if err := s.Tunnel.Setup(); err != nil {
 		return err
 	}
-	log.Println("firewall: Setting up routing tables")
-	/*	if err := firewall.FlushTables(); err != nil {
-		if !strings.HasPrefix(err.Error(), "firewall: Error flushing") {
-			return err
-		}
-	}*/
-	/*if check, err := checki2p.CheckI2PUserName(); err == nil {
-		log.Println("firewall: Tagging", check, "user firewall rules")
-		if err := firewall.Setup(localaddr.(*net.IPAddr).IP, remoteaddr.(*net.IPAddr).IP); err != nil {
-			log.Println("firewall: Error:", err.Error())
-			return err
-		}
-		log.Println("firewall: Adding", check, "to VPN Route")
-	} else {
-		log.Println("firewall: Error: router rule", err.Error())
-		return err
-	}
-	if check := checki2p.UserFind(); check != "" {
-		log.Println("firewall: Tagging", check, "user firewall rules")
-		if err := firewall.Setup(localaddr.(*net.IPAddr).IP, remoteaddr.(*net.IPAddr).IP); err != nil {
-			log.Println("firewall: Error:", err.Error())
-			return err
-		}
-		log.Println("firewall: Adding", check, "to VPN Route")
-		log.Println("firewall: Finished setting up routing tables")
-	} else {
-		log.Println("firewall: Error: user rule, user not found.")
-		return err
-	}*/
 	s.Tunnel.Run(ctx)
 	for {
 

--- a/cmd/anonvpn/common.go
+++ b/cmd/anonvpn/common.go
@@ -12,6 +12,7 @@ import (
 	samforwardervpn "github.com/RTradeLtd/libanonvpn/client"
 	samtunnelhandler "github.com/RTradeLtd/libanonvpn/ctrl"
 	samforwardervpnserver "github.com/RTradeLtd/libanonvpn/server"
+	"github.com/eyedeekay/canal/etc"
 	checki2p "github.com/eyedeekay/checki2cp"
 	i2pbrowserproxy "github.com/eyedeekay/httptunnel/multiproxy"
 	"github.com/eyedeekay/outproxy"
@@ -46,6 +47,18 @@ func lbMain(ctx context.Context) {
 			log.Fatal("Install or start i2p")
 		}
 	}
+	if *canal {
+		if *client {
+			if err := fwscript.Setup(*tunName); err != nil {
+				log.Fatal("Client firewall configuration error", err)
+			}
+		} else {
+			if err := fwscript.ServerSetup(*tunName, *gateName); err != nil {
+				log.Fatal("Server firewall configuration error", err)
+			}
+		}
+	}
+
 	config := &i2ptunconf.Conf{Config: goini.New()}
 	if *iniFile != "none" && *iniFile != "" {
 		config, err = i2ptunconf.NewI2PTunConf(*iniFile)

--- a/cmd/anonvpn/flags.go
+++ b/cmd/anonvpn/flags.go
@@ -40,6 +40,10 @@ var (
 		"(Server Only) Output a client config file to the specified path")
 	startUp = flag.Bool("start", true,
 		"Start a tunnel with the passed parameters(Otherwise, they will be treated as default values).")
+	canal = flag.Bool("canal", true,
+		"Run the canal subcommand to configure firewall rules(Experimental).")
+	gateName = flag.String("string", "192.168.0.1",
+		"Gateway to forward requests recieved by the server with canal(Experimental)")
 )
 
 // I2P Options
@@ -58,8 +62,6 @@ var (
 		"Close tunnel after idle for a specified time(true or false).")
 	client = flag.Bool("client", true,
 		"Client mode(true or false).")
-	/*server = flag.Bool("server", true,
-	"Server mode(true or false).")*/
 	peoplehash = flag.String("hashhash", "",
 		"32-word mnemonic representing a .b32.i2p address(will output .b32.i2p address and quit)")
 	sigType = flag.String("signaturetype", "",

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	crawshaw.io/littleboss v0.0.0-20190317185602-8957d0aedcce
 	github.com/eyedeekay/accessregister v0.0.0-20190908214045-2f83369c289b
+	github.com/eyedeekay/canal v0.0.26
 	github.com/eyedeekay/checki2cp v0.0.0-20191027173419-138f1b4882b2
 	github.com/eyedeekay/go-i2cp v0.0.0-20190711020517-c0bce4e7b750 // indirect
 	github.com/eyedeekay/httptunnel v0.0.0-20191017011116-3b144b52941f

--- a/server/vpn-server.go
+++ b/server/vpn-server.go
@@ -12,11 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
-
-	//	"time"
-
 	whitelister "github.com/eyedeekay/accessregister/auth"
-	//"github.com/eyedeekay/canal"
 	i2ptunconf "github.com/eyedeekay/sam-forwarder/config"
 	"github.com/eyedeekay/sam-forwarder/hashhash"
 	sfi2pkeys "github.com/eyedeekay/sam-forwarder/i2pkeys"
@@ -349,9 +345,6 @@ func (s *SAMClientServerVPN) Serve() error {
 		return err
 	}
 	go s.whiteListingTunnel.Serve()
-	/*if err = firewall.ServerSetup(s.Config().TunName, "eth0"); err != nil {
-		return err
-	}*/
 	s.Tunnel.Run(ctx)
 
 	return nil


### PR DESCRIPTION
This re-adds canal, which is used to configure Firewalls and Routing Tables for use with VPN's. It adds two flags, -canal and -gateway. Setting canal=true will invoke the canal command and exit without starting the VPN. On clients, this will configure traffic to go over the VPN by whatever reasonable way is provided by the OS. On servers, this will optionally forward traffic to a gateway.